### PR TITLE
Remove TokenURL and use APIURL for token requests

### DIFF
--- a/client.go
+++ b/client.go
@@ -30,15 +30,11 @@ const (
 	ProductionAPIURL = "https://api.dwolla.com"
 	// ProductionAuthURL is the production auth url
 	ProductionAuthURL = "https://www.dwolla.com/oauth/v2/authenticate"
-	// ProductionTokenURL is the production token url
-	ProductionTokenURL = "https://accounts.dwolla.com/token"
 
 	// SandboxAPIURL is the sandbox api url
 	SandboxAPIURL = "https://api-sandbox.dwolla.com"
 	// SandboxAuthURL is the sandbox auth url
 	SandboxAuthURL = "https://sandbox.dwolla.com/oauth/v2/authenticate"
-	// SandboxTokenURL is the sandbox token url
-	SandboxTokenURL = "https://accounts-sandbox.dwolla.com/token"
 )
 
 // Token is a dwolla auth token
@@ -163,20 +159,6 @@ func (c Client) AuthURL() string {
 	return url
 }
 
-// TokenURL returns the token url for the environment
-func (c Client) TokenURL() string {
-	var url string
-
-	switch c.Environment {
-	case Production:
-		url = ProductionTokenURL
-	case Sandbox:
-		url = SandboxTokenURL
-	}
-
-	return url
-}
-
 // RequestToken requests a new auth token using client credentials
 func (c *Client) RequestToken(ctx context.Context) error {
 	var (
@@ -186,7 +168,7 @@ func (c *Client) RequestToken(ctx context.Context) error {
 
 	buf := bytes.NewBuffer([]byte("grant_type=client_credentials"))
 
-	req, err := http.NewRequest("POST", c.TokenURL(), buf)
+	req, err := http.NewRequest("POST", c.BuildAPIURL("token"), buf)
 	if err != nil {
 		return err
 	}

--- a/client.go
+++ b/client.go
@@ -30,11 +30,17 @@ const (
 	ProductionAPIURL = "https://api.dwolla.com"
 	// ProductionAuthURL is the production auth url
 	ProductionAuthURL = "https://www.dwolla.com/oauth/v2/authenticate"
+	// ProductionTokenURL is the production token url
+	// Deprecated - use APIURL moving forward
+	ProductionTokenURL = "https://accounts.dwolla.com/token"
 
 	// SandboxAPIURL is the sandbox api url
 	SandboxAPIURL = "https://api-sandbox.dwolla.com"
 	// SandboxAuthURL is the sandbox auth url
 	SandboxAuthURL = "https://sandbox.dwolla.com/oauth/v2/authenticate"
+	// SandboxTokenURL is the sandbox token url
+	// Deprecated - use SandboxAPIURL moving forward
+	SandboxTokenURL = "https://accounts-sandbox.dwolla.com/token"
 )
 
 // Token is a dwolla auth token
@@ -154,6 +160,20 @@ func (c Client) AuthURL() string {
 		url = ProductionAuthURL
 	case Sandbox:
 		url = SandboxAuthURL
+	}
+
+	return url
+}
+
+// TokenURL returns the token url for the environment
+func (c Client) TokenURL() string {
+	var url string
+
+	switch c.Environment {
+	case Production:
+		url = ProductionTokenURL
+	case Sandbox:
+		url = SandboxTokenURL
 	}
 
 	return url

--- a/client.go
+++ b/client.go
@@ -31,7 +31,7 @@ const (
 	// ProductionAuthURL is the production auth url
 	ProductionAuthURL = "https://www.dwolla.com/oauth/v2/authenticate"
 	// ProductionTokenURL is the production token url
-	// Deprecated - use APIURL moving forward
+	// Deprecated - use https://api.dwolla.com/token moving forward
 	ProductionTokenURL = "https://accounts.dwolla.com/token"
 
 	// SandboxAPIURL is the sandbox api url
@@ -39,7 +39,7 @@ const (
 	// SandboxAuthURL is the sandbox auth url
 	SandboxAuthURL = "https://sandbox.dwolla.com/oauth/v2/authenticate"
 	// SandboxTokenURL is the sandbox token url
-	// Deprecated - use SandboxAPIURL moving forward
+	// Deprecated - use https://api-sandbox.dwolla.com moving forward
 	SandboxTokenURL = "https://accounts-sandbox.dwolla.com/token"
 )
 

--- a/client_test.go
+++ b/client_test.go
@@ -17,11 +17,13 @@ func TestClientEnvironment(t *testing.T) {
 
 	assert.Equal(t, productionClient.APIURL(), ProductionAPIURL)
 	assert.Equal(t, productionClient.AuthURL(), ProductionAuthURL)
+	assert.Equal(t, productionClient.TokenURL(), ProductionTokenURL)
 
 	sandboxClient := New("foobar", "barbaz", Sandbox)
 
 	assert.Equal(t, sandboxClient.APIURL(), SandboxAPIURL)
 	assert.Equal(t, sandboxClient.AuthURL(), SandboxAuthURL)
+	assert.Equal(t, sandboxClient.TokenURL(), SandboxTokenURL)
 }
 
 func TestClientRequestToken(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -17,13 +17,11 @@ func TestClientEnvironment(t *testing.T) {
 
 	assert.Equal(t, productionClient.APIURL(), ProductionAPIURL)
 	assert.Equal(t, productionClient.AuthURL(), ProductionAuthURL)
-	assert.Equal(t, productionClient.TokenURL(), ProductionTokenURL)
 
 	sandboxClient := New("foobar", "barbaz", Sandbox)
 
 	assert.Equal(t, sandboxClient.APIURL(), SandboxAPIURL)
 	assert.Equal(t, sandboxClient.AuthURL(), SandboxAuthURL)
-	assert.Equal(t, sandboxClient.TokenURL(), SandboxTokenURL)
 }
 
 func TestClientRequestToken(t *testing.T) {


### PR DESCRIPTION
Implements solution for https://github.com/kolanos/dwolla-v2-go/issues/4

Remove `TokenURL` and uses `APIURL` as the base for the token endpoint.